### PR TITLE
Fix for #4. Use pmset to lock Mac

### DIFF
--- a/geek/.geek/general.sh
+++ b/geek/.geek/general.sh
@@ -129,9 +129,10 @@ afk() {
     if [ -x "$(xflock4)" ]; then
         # XFCE
        echo "Locking XFCE session..."
-    elif [ -x "$(/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend)" ]; then
+    elif [ -x "/usr/bin/pmset" ]; then
         # macbooks
         echo "Locking Macbook..."
+        pmset displaysleepnow
     fi
 }
 


### PR DESCRIPTION
Fixes #4
- Check if `/usr/bin/pmset` is executable
- If it is call `pmset displaysleepnow`
- Tested successfully on macOS `12.1`

<img width="829" alt="Screenshot 2021-12-24 at 15 02 06" src="https://user-images.githubusercontent.com/30755149/147360964-4283faf1-5a63-4079-9348-7da566c56479.png">

Merry Christmas 😘🎅

